### PR TITLE
Updates to remove Python2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved from `f2py2` to `f2py3` to enable removal of Python 2 support
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved from `f2py2` to `f2py3` to enable removal of Python 2 support
-
 ### Fixed
 
 ### Removed
 
 ### Deprecated
+
+## [1.1.0] - 2025-09-09
+
+### Changed
+
+- Moved from `f2py2` to `f2py3` to enable removal of Python 2 support
 
 ## [1.0.0] - 2025-01-23
 

--- a/optics/CMakeLists.txt
+++ b/optics/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(miev_srcs 
+set(miev_srcs
    miev/ErrPack.f
    miev/MIEV0.F
    )
@@ -14,11 +14,11 @@ endforeach()
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if (USE_F2PY)
-   find_package(F2PY2)
-   if (F2PY2_FOUND)
-      esma_add_f2py2_module(optics_
+   find_package(F2PY3)
+   if (F2PY3_FOUND)
+      esma_add_f2py3_module(optics_
          SOURCES mie.F90
-         DESTINATION lib/Python2/optics
+         DESTINATION lib/Python/optics
          ONLY scattering_lognormal
          LIBRARIES miev
          INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR}
@@ -30,5 +30,5 @@ endif ()
 
 install(
    FILES radiation.py gads.py mam7-optics.lut.py
-   DESTINATION lib/Python2/optics
+   DESTINATION lib/Python/optics
    )


### PR DESCRIPTION
It is time to remove `f2py2` support (aka Python2 support) in GEOS. This PR is one of a series where we convert `f2py2` builds to `f2py3`.

Note: There might be more needed Python2 → Python3 changes in scripts that _use_ this `f2py3` module, but I can say that the modules *build* so `f2py3` has no issue.